### PR TITLE
Change default systemd target from graphical to multi-user

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ Changed::
 * Disable `AcceptEnv LANG LC_*` in `sshd_config`.
 * Change timezone from `Etc/UTC` to `Europe/Prague`.
 * Enable SSH daemon by creating empty file `/boot/ssh` instead of running `systemctl enable ssh` during build as before.
+* Change default systemd target from graphical to multi-user.
 
 Fixed::
 * Fix name of the bc-workroom-led-strip package (it has been renamed from “bc-workroom-ledstrip” to “bc-workroom-led-strip”).

--- a/pi-gen-overlay/stage2/10-bigclown/00-run.sh
+++ b/pi-gen-overlay/stage2/10-bigclown/00-run.sh
@@ -16,3 +16,8 @@ EOF
 on_chroot <<-EOF
 	raspi-config nonint do_serial 0
 EOF
+
+# Change default target from Graphical Interface to Multi-User System.
+on_chroot <<-EOF
+	systemctl set-default multi-user.target
+EOF


### PR DESCRIPTION
This system does not contain GUI, so it doesn't make sense to start into graphical mode.

This also “solves” failing noobs service that should not be started:

    apply_noobs_os_config.service start operation timed out. Terminating.
    failed to start apply_noobs_os_config.service.